### PR TITLE
[Fix] Recent breaking changes from snake_case and double quotes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -80,6 +80,7 @@ const defaultOpts: TinyFixturesOptions = {
 
 /**
  * @param pool A node postgres pool for tiny fixtures to connect with.
+ * @param { convertToSnakecase: boolean = false } options
  */
 export const tinyFixtures = (
   pool: Pool,

--- a/src/query.ts
+++ b/src/query.ts
@@ -34,7 +34,9 @@ export const buildInsertQueryString = (
   row: Row,
   convertToSnakecase: boolean
 ) => `
-  INSERT INTO ${convertToSnakecase ? resolveTableSnakeCase(table) : wrapDoubleQuotes(table)}
+  INSERT INTO ${
+    convertToSnakecase ? resolveTableSnakeCase(table) : wrapDoubleQuotes(table)
+  }
   ${buildInsertColumnString(row, convertToSnakecase)}
   VALUES
   ${buildInsertValueBindingString(row)}
@@ -58,7 +60,9 @@ export const buildDeleteQueryString = (
   }
   const pkValues = keys.map((k) => (typeof k === 'number' ? k : `'${k}'`));
   return `
-  DELETE FROM ${convertToSnakecase ? resolveTableSnakeCase(table) : wrapDoubleQuotes(table)}
+  DELETE FROM ${
+    convertToSnakecase ? resolveTableSnakeCase(table) : wrapDoubleQuotes(table)
+  }
   WHERE "${
     convertToSnakecase ? snakeCase(pkName) : pkName
   }" IN (${pkValues.join(', ')})

--- a/src/query.ts
+++ b/src/query.ts
@@ -3,9 +3,25 @@ import { snakeCase } from 'snake-case';
 
 type Row = Record<string, any>;
 
+const wrapDoubleQuotes = (string: string): string => {
+  if (string.indexOf('.') >= 0 || string.startsWith('"')) {
+    return string;
+  }
+
+  return `"${string}"`;
+};
+
+const resolveTableSnakeCase = (table: string): string => {
+  const tableParts = table.split('.');
+
+  return tableParts.length > 1
+    ? `${tableParts[0]}."${snakeCase(tableParts[1])}"`
+    : wrapDoubleQuotes(snakeCase(table));
+};
+
 const buildInsertColumnString = (row: Row, convertToSnakecase: boolean) =>
   `(${Object.keys(row)
-    .map((k) => `"${convertToSnakecase ? snakeCase(k) : k}"`)
+    .map((k) => wrapDoubleQuotes(convertToSnakecase ? snakeCase(k) : k))
     .join(', ')})`;
 
 const buildInsertValueBindingString = (row: Row) =>
@@ -13,16 +29,16 @@ const buildInsertValueBindingString = (row: Row) =>
     .map((_, i) => `$${i + 1}`)
     .join(', ')})`;
 
-const buildInsertQueryString = (
+export const buildInsertQueryString = (
   table: string,
   row: Row,
   convertToSnakecase: boolean
 ) => `
-    INSERT INTO "${convertToSnakecase ? snakeCase(table) : table}"
-    ${buildInsertColumnString(row, convertToSnakecase)}
-    VALUES
-    ${buildInsertValueBindingString(row)}
-    RETURNING *
+  INSERT INTO ${convertToSnakecase ? resolveTableSnakeCase(table) : wrapDoubleQuotes(table)}
+  ${buildInsertColumnString(row, convertToSnakecase)}
+  VALUES
+  ${buildInsertValueBindingString(row)}
+  RETURNING *
 `;
 
 export const buildDeleteQueryString = (
@@ -42,7 +58,7 @@ export const buildDeleteQueryString = (
   }
   const pkValues = keys.map((k) => (typeof k === 'number' ? k : `'${k}'`));
   return `
-  DELETE FROM "${convertToSnakecase ? snakeCase(table) : table}"
+  DELETE FROM ${convertToSnakecase ? resolveTableSnakeCase(table) : wrapDoubleQuotes(table)}
   WHERE "${
     convertToSnakecase ? snakeCase(pkName) : pkName
   }" IN (${pkValues.join(', ')})

--- a/src/query.ts
+++ b/src/query.ts
@@ -15,7 +15,7 @@ const resolveTableSnakeCase = (table: string): string => {
   const tableParts = table.split('.');
 
   return tableParts.length > 1
-    ? `${tableParts[0]}."${snakeCase(tableParts[1])}"`
+    ? `${tableParts[0]}.${wrapDoubleQuotes(snakeCase(tableParts[1]))}`
     : wrapDoubleQuotes(snakeCase(table));
 };
 

--- a/test/db/conn.ts
+++ b/test/db/conn.ts
@@ -1,4 +1,4 @@
-import {Pool} from 'pg';
+import { Pool } from 'pg';
 
 export const pool = new Pool({
   host: process.env.DatabaseHost || 'localhost',

--- a/test/db/users.ts
+++ b/test/db/users.ts
@@ -6,19 +6,19 @@ export type User = {
   username: string;
   createdAt: Date;
   messages: Message[];
-}
+};
 
 type Message = {
   message: string;
   createdAt: Date;
-}
+};
 
 type UserTable = {
   id: string;
   email: string;
   username: string;
   created_at: Date;
-}
+};
 
 type MessageTable = {
   id: string;
@@ -27,12 +27,20 @@ type MessageTable = {
   created_at: Date;
 };
 
-const mapMessageTableToMessage = ({message, created_at}: MessageTable): Message => ({
+const mapMessageTableToMessage = ({
+  message,
+  created_at,
+}: MessageTable): Message => ({
   message,
   createdAt: created_at,
 });
 
-const mapUserTableToUser = async ({ id, email, username, created_at }: UserTable): Promise<User> =>({
+const mapUserTableToUser = async ({
+  id,
+  email,
+  username,
+  created_at,
+}: UserTable): Promise<User> => ({
   id: parseInt(id, 10),
   email,
   username,
@@ -43,14 +51,17 @@ const mapUserTableToUser = async ({ id, email, username, created_at }: UserTable
 export const getUsers = async (): Promise<User[]> => {
   const result = await pool.query<UserTable>(`
     SELECT * FROM users ORDER BY id
-  `)
+  `);
   return Promise.all([...result.rows.map(mapUserTableToUser)]);
-}
+};
 
 const getUserMessages = async (id: string): Promise<Message[]> => {
-  const result = await pool.query<MessageTable>(`
+  const result = await pool.query<MessageTable>(
+    `
     SELECT * FROM user_messages
     WHERE user_id = $1
-  `, [id]);
+  `,
+    [id]
+  );
   return result.rows.map(mapMessageTableToMessage);
-}
+};

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -7,16 +7,19 @@ const { createFixtures } = tinyFixtures(pool);
 
 describe('integration test the whole library', () => {
   describe('Basic single table use case', () => {
-    const [setupUserFixtures, teardownUserFixtures] = createFixtures('public.users', [
-      {
-        email: 'foo@bar.co',
-        username: 'tinyAnt',
-      },
-      {
-        email: 'bar@foo.co',
-        username: 'antTiny',
-      },
-    ]);
+    const [setupUserFixtures, teardownUserFixtures] = createFixtures(
+      'public.users',
+      [
+        {
+          email: 'foo@bar.co',
+          username: 'tinyAnt',
+        },
+        {
+          email: 'bar@foo.co',
+          username: 'antTiny',
+        },
+      ]
+    );
     beforeEach(async () => {
       await setupUserFixtures();
     });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -7,7 +7,7 @@ const { createFixtures } = tinyFixtures(pool);
 
 describe('integration test the whole library', () => {
   describe('Basic single table use case', () => {
-    const [setupUserFixtures, teardownUserFixtures] = createFixtures('users', [
+    const [setupUserFixtures, teardownUserFixtures] = createFixtures('public.users', [
       {
         email: 'foo@bar.co',
         username: 'tinyAnt',

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -27,17 +27,32 @@ describe('query functions', function () {
     });
 
     it('builds a delete query string with multiple ids', () => {
-      const actual = buildDeleteQueryString('test', 'test_id', [1, 2, 3], false);
+      const actual = buildDeleteQueryString(
+        'test',
+        'test_id',
+        [1, 2, 3],
+        false
+      );
       expect(actual).to.equal(expectedTwo);
     });
 
     it('builds a delete query string with string ids', () => {
-      const actual = buildDeleteQueryString('test', 'test_id', ['1', '2', '3'], false);
+      const actual = buildDeleteQueryString(
+        'test',
+        'test_id',
+        ['1', '2', '3'],
+        false
+      );
       expect(actual).to.equal(expectedThree);
     });
 
     it('builds a delete query string with mixed ids', () => {
-      const actual = buildDeleteQueryString('test', 'test_id', ['1', 2, '3'], false);
+      const actual = buildDeleteQueryString(
+        'test',
+        'test_id',
+        ['1', 2, '3'],
+        false
+      );
       expect(actual).to.equal(expectedFour);
     });
 
@@ -95,10 +110,14 @@ describe('query functions', function () {
 
   describe('buildInsertQueryString', () => {
     it('returns the insert query with schema', () => {
-      const actual = buildInsertQueryString('public."users"', {
-        first_name: 'Seth',
-        last_name: 'Tran',
-      }, false);
+      const actual = buildInsertQueryString(
+        'public."users"',
+        {
+          first_name: 'Seth',
+          last_name: 'Tran',
+        },
+        false
+      );
 
       expect(actual).to.equal(`
   INSERT INTO public."users"
@@ -110,10 +129,14 @@ describe('query functions', function () {
     });
 
     it('returns the insert query without schema', () => {
-      const actual = buildInsertQueryString('users', {
-        first_name: 'Ant',
-        last_name: 'Man',
-      }, false);
+      const actual = buildInsertQueryString(
+        'users',
+        {
+          first_name: 'Ant',
+          last_name: 'Man',
+        },
+        false
+      );
 
       expect(actual).to.equal(`
   INSERT INTO "users"
@@ -125,10 +148,14 @@ describe('query functions', function () {
     });
 
     it('returns the insert query with schema automatically converted to snake_case', () => {
-      const actual = buildInsertQueryString('public."superUsers"', {
-        first_name: 'God',
-        last_name: 'Mode',
-      }, true);
+      const actual = buildInsertQueryString(
+        'public."superUsers"',
+        {
+          first_name: 'God',
+          last_name: 'Mode',
+        },
+        true
+      );
 
       expect(actual).to.equal(`
   INSERT INTO public."super_users"

--- a/test/query.test.ts
+++ b/test/query.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { buildDeleteQueryString } from '../src/query';
+import { buildDeleteQueryString, buildInsertQueryString } from '../src/query';
 import { findPrimaryKeyName } from '../src/query';
 import { FieldDef, QueryResult } from 'pg';
 
@@ -90,6 +90,53 @@ describe('query functions', function () {
     });
     it('returns the field name of column 1', () => {
       expect(findPrimaryKeyName(fieldsGood)).to.equal('id');
+    });
+  });
+
+  describe('buildInsertQueryString', () => {
+    it('returns the insert query with schema', () => {
+      const actual = buildInsertQueryString('public."users"', {
+        first_name: 'Seth',
+        last_name: 'Tran',
+      }, false);
+
+      expect(actual).to.equal(`
+  INSERT INTO public."users"
+  ("first_name", "last_name")
+  VALUES
+  ($1, $2)
+  RETURNING *
+`);
+    });
+
+    it('returns the insert query without schema', () => {
+      const actual = buildInsertQueryString('users', {
+        first_name: 'Ant',
+        last_name: 'Man',
+      }, false);
+
+      expect(actual).to.equal(`
+  INSERT INTO "users"
+  ("first_name", "last_name")
+  VALUES
+  ($1, $2)
+  RETURNING *
+`);
+    });
+
+    it('returns the insert query with schema automatically converted to snake_case', () => {
+      const actual = buildInsertQueryString('public."superUsers"', {
+        first_name: 'God',
+        last_name: 'Mode',
+      }, true);
+
+      expect(actual).to.equal(`
+  INSERT INTO public."super_users"
+  ("first_name", "last_name")
+  VALUES
+  ($1, $2)
+  RETURNING *
+`);
     });
   });
 });


### PR DESCRIPTION
## Fix

This provides backward compatibility and some improvements to ensure snake_case works normally.

### Fix 1

`v0.2.6` added the `"` while generating Query to table & columns. It would fail from userland if they added like this:

```js
createFixtures('"users"', ...); // INSERT INTO ""users""` - syntax error
createFixtures('public."users"', ...); // INSERT INTO "public."users""` - syntax error
```

Added a fix if the table is already wrapped with quotes => no need to wrap again.

### Fix 2

It is a new nice-feature to convert camel to snake, but if we pass the table together with the schema, it would generate a wrong query, eg:

- public.users => public_users
- public."users" => public_users

Added a fix to ensure the scheme won't be changed, only the table name.